### PR TITLE
Add .pt file extension as PyTorch

### DIFF
--- a/trains/model.py
+++ b/trains/model.py
@@ -53,6 +53,7 @@ class Framework(Options):
         'model.json': (tensorflowjs, ),
         '.tflite': (tensorflowlite, ),
         '.pth': (pytorch, ),
+        '.pt': (pytorch, ),
         '.caffemodel': (caffe, ),
         '.prototxt': (caffe, ),
         'predict_net.pb': (caffe2, ),


### PR DESCRIPTION
Usually `.pt` is used as pytorch's extension, see [this StackOverflow question](https://stackoverflow.com/questions/59095824/what-is-difference-between-pt-pth-and-pwf-extentions-in-pytorch).

Furthermore `.pth` is used by Python to list additional package search paths (see [this PyTorch issue](https://github.com/pytorch/pytorch/issues/14864)) so IMO it might be worth to reconsider whether `.pth` should exist. AFAIK `.pt` is advised and used throughout most projects.