### PR TITLE
Import ABC from collections.abc instead of collections for Python 3.9 compatibility.

### DIFF
--- a/trains/backend_interface/metrics/reporter.py
+++ b/trains/backend_interface/metrics/reporter.py
@@ -1,5 +1,9 @@
-import collections
 import json
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import six
 import numpy as np
@@ -152,7 +156,7 @@ class Reporter(InterfaceBase, AbstractContextManager, SetupUploadMixin, AsyncMan
         :param iter: Iteration number
         :type value: int
         """
-        if not isinstance(values, collections.Iterable):
+        if not isinstance(values, Iterable):
             raise ValueError('values: expected an iterable')
         ev = VectorEvent(metric=self._normalize_name(title), variant=self._normalize_name(series), values=values, iter=iter)
         self._report(ev)

--- a/trains/backend_interface/task/task.py
+++ b/trains/backend_interface/task/task.py
@@ -1,11 +1,15 @@
 """ Backend task management support """
-import collections
 import itertools
 import logging
 import os
 from enum import Enum
 from threading import Thread
 from multiprocessing import RLock
+
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import six
 from six.moves.urllib.parse import quote
@@ -587,7 +591,7 @@ class Task(IdObjectBase, AccessMixin, SetupUploadMixin):
             a single key/value dictionary.
         :param kwargs: Key/value pairs, merged into the parameters dictionary created from `args`.
         """
-        if not all(isinstance(x, (dict, collections.Iterable)) for x in args):
+        if not all(isinstance(x, (dict, Iterable)) for x in args):
             raise ValueError('only dict or iterable are supported as positional arguments')
 
         update = kwargs.pop('__update', False)

--- a/trains/task.py
+++ b/trains/task.py
@@ -5,13 +5,12 @@ import sys
 import threading
 import time
 from argparse import ArgumentParser
-from collections import Callable
 from tempfile import mkstemp
 
 try:
-    from collections.abc import Sequence
+    from collections.abc import Callable, Sequence
 except ImportError:
-    from collections import Sequence
+    from collections import Callable, Sequence
 
 from typing import Optional
 


### PR DESCRIPTION
Fixes #110 