### PR TITLE
Only install typing dependency on Python<3.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -20,5 +20,5 @@ requests-file>=1.4.2
 requests>=2.20.0
 six>=1.11.0
 tqdm>=4.19.5
-typing>=3.6.4
+typing>=3.6.4 ; python_version < '3.5'
 urllib3>=1.21.1


### PR DESCRIPTION
Installing `typing` on recent Python versions leads to the error described in python/typing#573 (running tests with tox yields `AttributeError: type object 'Callable' has no attribute '_abc_registry'`).

The [`typing` readme](https://pypi.org/project/typing/) suggests to install the package only for Python versions <3.5, which this commit does.