### PR TITLE
Fix lightgbm binding keyword argument bugs

### DIFF
--- a/trains/binding/frameworks/lightgbm_bind.py
+++ b/trains/binding/frameworks/lightgbm_bind.py
@@ -118,11 +118,19 @@ class PatchLIGHTgbmModelIO(PatchBaseModelIO):
                 except Exception:
                     pass
             return callback
-        params, train_set = args
+        
+        if args:
+            kwargs['params'] = args.pop(0)
+        if args:
+            kwargs['train_set'] = args.pop(0)
+        if args:
+            raise ValueError('It only supports 2 position argument {params} and {trian_set}')
+
         kwargs.setdefault("callbacks", []).append(trains_lightgbm_callback())
-        ret = original_fn(params, train_set, **kwargs)
+        ret = original_fn(**kwargs)
         if not PatchLIGHTgbmModelIO.__main_task:
             return ret
+        params = kwargs['params']
         for k, v in params.items():
             if isinstance(v, set):
                 params[k] = list(v)

--- a/trains/binding/frameworks/lightgbm_bind.py
+++ b/trains/binding/frameworks/lightgbm_bind.py
@@ -120,11 +120,11 @@ class PatchLIGHTgbmModelIO(PatchBaseModelIO):
             return callback
         
         if args:
-            kwargs['params'] = args.pop(0)
-        if args:
-            kwargs['train_set'] = args.pop(0)
-        if args:
-            raise ValueError('It only supports 2 position argument {params} and {trian_set}')
+            kwargs['params'] = args[0]
+            if len(args) == 2:
+                kwargs['train_set'] = args[1]
+            elif len(args) > 2:
+                raise ValueError('It only supports 2 position argument {params} and {trian_set}')
 
         kwargs.setdefault("callbacks", []).append(trains_lightgbm_callback())
         ret = original_fn(**kwargs)

--- a/trains/binding/frameworks/lightgbm_bind.py
+++ b/trains/binding/frameworks/lightgbm_bind.py
@@ -119,18 +119,11 @@ class PatchLIGHTgbmModelIO(PatchBaseModelIO):
                     pass
             return callback
         
-        if args:
-            kwargs['params'] = args[0]
-            if len(args) == 2:
-                kwargs['train_set'] = args[1]
-            elif len(args) > 2:
-                raise ValueError('It only supports 2 position argument {params} and {trian_set}')
-
         kwargs.setdefault("callbacks", []).append(trains_lightgbm_callback())
-        ret = original_fn(**kwargs)
+        ret = original_fn(*args, **kwargs)
         if not PatchLIGHTgbmModelIO.__main_task:
             return ret
-        params = kwargs['params']
+        params = args[0] if args else kwargs['params']
         for k, v in params.items():
             if isinstance(v, set):
                 params[k] = list(v)


### PR DESCRIPTION
Prevent error when user using keyword arguments instead of positional arguments
Related: #250 

lgb.train support positional arguments, but user can pass it as a keyword arguments. Previously code will fail if args is empty.

This fix attempt to catch positional arguments into `kwargs` if exist, so it can support both positional/keyword arguments.