### PR TITLE
Allow to disable SSL certificates verification when using a Non-AWS S3 solution

### DIFF
--- a/trains/backend_config/bucket_config.py
+++ b/trains/backend_config/bucket_config.py
@@ -29,6 +29,7 @@ class S3BucketConfig(object):
     acl = attrib(type=str, converter=_none_to_empty_string, default="")
     secure = attrib(type=bool, default=True)
     region = attrib(type=str, converter=_none_to_empty_string, default="")
+    verify = attrib(type=bool, default=True)
 
     def update(self, key, secret, multipart=True, region=None):
         self.key = key

--- a/trains/backend_interface/setupuploadmixin.py
+++ b/trains/backend_interface/setupuploadmixin.py
@@ -9,7 +9,7 @@ class SetupUploadMixin(object):
     storage_uri = abstractproperty()
 
     def setup_upload(
-            self, bucket_name, host=None, access_key=None, secret_key=None, region=None, multipart=True, https=True):
+            self, bucket_name, host=None, access_key=None, secret_key=None, region=None, multipart=True, https=True, verify=True):
         """
         Setup upload options (currently only S3 is supported)
 
@@ -30,6 +30,8 @@ class SetupUploadMixin(object):
         :type https: bool
         :param region: Bucket region. Required if the bucket doesn't reside in the default region (us-east-1)
         :type region: str
+        :param verify: Whether or not to verify SSL certificates. Only required when using a Non-AWS S3 solution that only supports HTTPS with self-signed certificate.
+        :type verify: bool
         """
         self._bucket_config = S3BucketConfig(
             bucket=bucket_name,
@@ -38,7 +40,8 @@ class SetupUploadMixin(object):
             secret=secret_key,
             multipart=multipart,
             secure=https,
-            region=region
+            region=region,
+            verify=verify
         )
         self.storage_uri = ('s3://%(host)s/%(bucket_name)s' if host else 's3://%(bucket_name)s') % locals()
         StorageHelper.add_configuration(self._bucket_config, log=self.log)

--- a/trains/storage/helper.py
+++ b/trains/storage/helper.py
@@ -1236,6 +1236,7 @@ class _Boto3Driver(_Driver):
                     aws_secret_access_key=cfg.secret,
                     endpoint_url=endpoint,
                     use_ssl=cfg.secure,
+                    verify=cfg.verify,
                     config=botocore.client.Config(
                         max_pool_connections=max(
                             _Boto3Driver._min_pool_connections,


### PR DESCRIPTION
allow to disable SSL certificates verification when using a Non-AWS S3 solution that only supports HTTPS with self-signed certificate.

ref: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/core/session.html